### PR TITLE
Refactor journal entry helper

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Thtg88\LaravelBaseClasses\Database\Factories;
+
+use Thtg88\LaravelBaseClasses\Models\User;
+use Illuminate\Support\Str;
+
+class UserFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = User::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            // 'first_name' => $this->faker->firstName,
+            // 'last_name' => $this->faker->lastName,
+            'email' => $this->faker->unique()->safeEmail,
+            'email_verified_at' => now()->toDateTimeString(),
+            'password' => 'password',
+            'remember_token' => Str::random(10),
+        ];
+    }
+
+    /**
+     * Indicate that the model's email address should be unverified.
+     *
+     * @return \Illuminate\Database\Eloquent\Factories\Factory
+     */
+    public function unverified()
+    {
+        return ['email_verified_at' => null];
+    }
+}

--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            // Leaving name out as it's app dependent
+            // First and last name might be more useful for certain apps
+            // $table->string('first_name');
+            // $table->string('last_name');
+            $table->string('email')->index();
+            $table->string('password');
+            $table->rememberToken();
+            $table->timestamp('email_verified_at')->nullable();
+            $table->softDeletes();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('users');
+    }
+}

--- a/database/migrations/2019_06_01_000000_create_journal_entries_table.php
+++ b/database/migrations/2019_06_01_000000_create_journal_entries_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateJournalEntriesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('journal_entries', function (Blueprint $table) {
+            $table->id('id');
+            $table->unsignedBigInteger('user_id')->nullable()->index();
+            $table->unsignedBigInteger('target_id')->nullable();
+            $table->string('target_table')->nullable();
+            $table->string('action')->nullable()->index();
+            $table->text('content')->nullable();
+            $table->timestamps();
+
+            $table->index(['target_id', 'target_table']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('journal_entries');
+    }
+}

--- a/database/migrations/2019_06_01_000000_create_journal_entries_table.php
+++ b/database/migrations/2019_06_01_000000_create_journal_entries_table.php
@@ -17,12 +17,12 @@ class CreateJournalEntriesTable extends Migration
             $table->id('id');
             $table->unsignedBigInteger('user_id')->nullable()->index();
             $table->unsignedBigInteger('target_id')->nullable();
-            $table->string('target_table')->nullable();
+            $table->string('target_type')->nullable();
             $table->string('action')->nullable()->index();
             $table->text('content')->nullable();
             $table->timestamps();
 
-            $table->index(['target_id', 'target_table']);
+            $table->index(['target_id', 'target_type']);
         });
     }
 

--- a/database/migrations/2019_06_01_000000_create_journal_entries_table.php
+++ b/database/migrations/2019_06_01_000000_create_journal_entries_table.php
@@ -19,7 +19,7 @@ class CreateJournalEntriesTable extends Migration
             $table->unsignedBigInteger('target_id')->nullable();
             $table->string('target_type')->nullable();
             $table->string('action')->nullable()->index();
-            $table->text('content')->nullable();
+            $table->jsonb('content')->nullable();
             $table->timestamps();
 
             $table->index(['target_id', 'target_type']);

--- a/src/Helpers/JournalEntryHelper.php
+++ b/src/Helpers/JournalEntryHelper.php
@@ -74,7 +74,7 @@ class JournalEntryHelper
             );
         }
 
-        $data['content'] = json_encode($content);
+        $data['content'] = $content;
 
         return $this->journal_entries->create($data);
     }

--- a/src/Helpers/JournalEntryHelper.php
+++ b/src/Helpers/JournalEntryHelper.php
@@ -45,23 +45,8 @@ class JournalEntryHelper
         ?Model $model,
         ?array $content = null
     ): JournalEntry {
-        $target_table = null;
-        $id = null;
-        if ($model !== null) {
-            // Get model class name
-            $class_name = get_class($model);
-
-            // Get morph map
-            $morph_map = Relation::morphMap();
-
-            // Get target table for model
-            $target_table = array_search($class_name, $morph_map);
-            if ($target_table === false) {
-                $target_table = null;
-            }
-
-            $id = $model->id;
-        }
+        $target_table = $this->getTargetTable($model);
+        $id = $model->id ?? null;
 
         // Get current authenticated user
         $user = auth()->user();
@@ -89,5 +74,27 @@ class JournalEntryHelper
         }
 
         return $this->journal_entries->create($data);
+    }
+
+    private function getTargetTable(?Model $model): ?string
+    {
+        if ($model === null) {
+            return null;
+        }
+
+        // Get model class name
+        $class_name = get_class($model);
+
+        // Get morph map
+        $morph_map = Relation::morphMap();
+
+        // Get target table for model
+        $target_table = array_search($class_name, $morph_map);
+
+        if ($target_table === false) {
+            return null;
+        }
+
+        return $target_table;
     }
 }

--- a/src/Helpers/JournalEntryHelper.php
+++ b/src/Helpers/JournalEntryHelper.php
@@ -41,7 +41,7 @@ class JournalEntryHelper
      * @return \Thtg88\LaravelBaseClasses\Models\JournalEntry
      */
     public function createJournalEntry(
-        $action,
+        string $action,
         ?Model $model,
         ?array $content = null
     ): JournalEntry {

--- a/src/Helpers/JournalEntryHelper.php
+++ b/src/Helpers/JournalEntryHelper.php
@@ -45,7 +45,7 @@ class JournalEntryHelper
         ?Model $model = null,
         ?array $content = null
     ): JournalEntry {
-        $target_table = $this->getTargetTable($model);
+        $target_type = $this->getTargetType($model);
         $id = $model->id ?? null;
 
         // Get current authenticated user
@@ -54,7 +54,7 @@ class JournalEntryHelper
         // Build data array to save journal entry
         $data = [
             'target_id'    => $id,
-            'target_table' => $target_table,
+            'target_type' => $target_type,
             'action'       => $action,
         ];
 
@@ -79,7 +79,7 @@ class JournalEntryHelper
         return $this->journal_entries->create($data);
     }
 
-    private function getTargetTable(?Model $model): ?string
+    private function getTargetType(?Model $model): ?string
     {
         if ($model === null) {
             return null;
@@ -92,12 +92,12 @@ class JournalEntryHelper
         $morph_map = Relation::morphMap();
 
         // Get target table for model
-        $target_table = array_search($class_name, $morph_map);
+        $target_type = array_search($class_name, $morph_map);
 
-        if ($target_table === false) {
+        if ($target_type === false) {
             return null;
         }
 
-        return $target_table;
+        return $target_type;
     }
 }

--- a/src/Helpers/JournalEntryHelper.php
+++ b/src/Helpers/JournalEntryHelper.php
@@ -36,14 +36,14 @@ class JournalEntryHelper
      *
      * @param string                                   $action  The action performing while creating the entry.
      * @param \Illuminate\Database\Eloquent\Model|null $model   The model the action is performed on.
-     * @param array                                    $content The action content data.
+     * @param array|null                               $content The action content data.
      *
      * @return \Thtg88\LaravelBaseClasses\Models\JournalEntry
      */
     public function createJournalEntry(
         $action,
         ?Model $model,
-        array $content = null
+        ?array $content = null
     ): JournalEntry {
         $target_table = null;
         $id = null;

--- a/src/Helpers/JournalEntryHelper.php
+++ b/src/Helpers/JournalEntryHelper.php
@@ -42,7 +42,7 @@ class JournalEntryHelper
      */
     public function createJournalEntry(
         string $action,
-        ?Model $model,
+        ?Model $model = null,
         ?array $content = null
     ): JournalEntry {
         $target_table = $this->getTargetTable($model);

--- a/src/Helpers/JournalEntryHelper.php
+++ b/src/Helpers/JournalEntryHelper.php
@@ -63,15 +63,18 @@ class JournalEntryHelper
         }
 
         if ($content === null) {
-            $data['content'] = null;
-        } else {
-            // Remove hidden attributes from being posted in the journals (e.g. password)
-            $content = $model === null ?
-                $content :
-                array_diff_key($content, array_flip($model->getHidden()));
-
-            $data['content'] = json_encode($content);
+            return $this->journal_entries->create($data);
         }
+
+        // Remove hidden attributes from being posted in the journals (e.g. password)
+        if ($model !== null) {
+            $content = array_diff_key(
+                $content,
+                array_flip($model->getHidden())
+            );
+        }
+
+        $data['content'] = json_encode($content);
 
         return $this->journal_entries->create($data);
     }

--- a/src/Models/JournalEntry.php
+++ b/src/Models/JournalEntry.php
@@ -32,6 +32,7 @@ class JournalEntry extends Model
      * @var array
      */
     protected $casts = [
+        'content'    => 'array',
         'created_at' => 'datetime',
         'target_id'  => 'integer',
         'updated_at' => 'datetime',

--- a/src/Models/JournalEntry.php
+++ b/src/Models/JournalEntry.php
@@ -21,7 +21,7 @@ class JournalEntry extends Model
         'content',
         'created_at',
         'target_id',
-        'target_table',
+        'target_type',
         'updated_at',
         'user_id',
     ];

--- a/src/Models/JournalEntry.php
+++ b/src/Models/JournalEntry.php
@@ -2,11 +2,15 @@
 
 namespace Thtg88\LaravelBaseClasses\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 class JournalEntry extends Model
 {
+    use HasFactory;
+
     /**
      * The attributes that are mass assignable.
      *
@@ -16,7 +20,6 @@ class JournalEntry extends Model
         'action',
         'content',
         'created_at',
-        'deleted_at',
         'target_id',
         'target_table',
         'updated_at',
@@ -30,7 +33,6 @@ class JournalEntry extends Model
      */
     protected $casts = [
         'created_at' => 'datetime',
-        'deleted_at' => 'datetime',
         'target_id'  => 'integer',
         'updated_at' => 'datetime',
         'user_id'    => 'integer',

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Facades\Hash;
+use Thtg88\LaravelBaseClasses\Database\Factories\UserFactory;
 
 class User extends Authenticatable implements MustVerifyEmail
 {
@@ -71,5 +72,15 @@ class User extends Authenticatable implements MustVerifyEmail
     public function journal_entries(): MorphMany
     {
         return $this->morphMany(JournalEntry::class, 'target');
+    }
+
+    /**
+     * Create a new factory instance for the model.
+     *
+     * @return \Illuminate\Database\Eloquent\Factories\Factory
+     */
+    protected static function newFactory()
+    {
+        return UserFactory::new();
     }
 }

--- a/src/Repositories/Concerns/WithCreate.php
+++ b/src/Repositories/Concerns/WithCreate.php
@@ -89,7 +89,7 @@ trait WithCreate
                 'create-bulk',
                 null,
                 [
-                    'target_table' => $this->model->getTable(),
+                    'target_type'  => $this->model->getTable(),
                     'data'         => $data,
                 ]
             );

--- a/src/Repositories/Concerns/WithDestroy.php
+++ b/src/Repositories/Concerns/WithDestroy.php
@@ -60,7 +60,7 @@ trait WithDestroy
                 'delete-bulk',
                 null,
                 [
-                    'target_table' => $this->model->getTable(),
+                    'target_type'  => $this->model->getTable(),
                     'ids'          => $ids,
                 ]
             );

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -15,6 +15,7 @@ abstract class TestCase extends OrchestraTestCase
         Schema::create('test_models', function (Blueprint $table) {
             $table->id();
             $table->uuid('uuid');
+            $table->string('secret')->nullable();
             $table->dateTime('start_date');
             $table->dateTime('end_date');
             $table->softDeletes();

--- a/tests/TestClasses/Models/TestModel.php
+++ b/tests/TestClasses/Models/TestModel.php
@@ -20,6 +20,7 @@ class TestModel extends Model
     protected $fillables = [
         'end_date',
         'start_date',
+        'secret',
         'uuid',
     ];
 
@@ -35,6 +36,13 @@ class TestModel extends Model
         'start_date' => 'datetime',
         'updated_at' => 'datetime',
     ];
+
+    /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var array
+     */
+    protected $hidden = ['secret'];
 
     /**
      * Create a new factory instance for the model.

--- a/tests/Unit/Helpers/JournalEntryHelperTest.php
+++ b/tests/Unit/Helpers/JournalEntryHelperTest.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Tests\Unit\Helpers;
+
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Facades\Auth;
+use Thtg88\LaravelBaseClasses\Helpers\JournalEntryHelper;
+use Thtg88\LaravelBaseClasses\Models\JournalEntry;
+use Thtg88\LaravelBaseClasses\Models\User;
+use Thtg88\LaravelBaseClasses\Tests\TestCase;
+use Thtg88\LaravelBaseClasses\Tests\TestClasses\Models\TestModel;
+use Thtg88\LaravelBaseClasses\Tests\TestClasses\Repositories\TestModelRepository;
+
+class JournalEntryHelperTest extends TestCase
+{
+    private JournalEntryHelper $helper;
+    private TestModel $model;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->loadMigrationsFrom(__DIR__ . '/../../../database/migrations');
+
+        $this->artisan('migrate', [
+            '--path' => [__DIR__.'/../../../database/migrations'],
+        ]);
+
+        $this->helper = app()->make(JournalEntryHelper::class);
+        $this->model = TestModel::factory()->create();
+
+        // This is so that the correct target type can be set on journal entries table
+        Relation::morphMap(['test_models' => TestModel::class]);
+    }
+
+    /**
+     * @test
+     * @covers \Thtg88\LaravelBaseClasses\Helpers\JournalEntryHelper::createJournalEntry
+     */
+    public function action_gets_set_test(): void
+    {
+        $expected = 'ABCD';
+
+        $journal_entry = $this->helper->createJournalEntry($expected);
+
+        $this->assertNotNull($journal_entry);
+        $this->assertInstanceOf(JournalEntry::class, $journal_entry);
+        $this->assertEquals($expected, $journal_entry->action);
+    }
+
+    /**
+     * @test
+     * @covers \Thtg88\LaravelBaseClasses\Helpers\JournalEntryHelper::createJournalEntry
+     */
+    public function user_id_is_null_if_not_logged_in_test(): void
+    {
+        $expected = null;
+
+        $journal_entry = $this->helper->createJournalEntry('ABCD');
+
+        $this->assertNotNull($journal_entry);
+        $this->assertInstanceOf(JournalEntry::class, $journal_entry);
+        $this->assertEquals($expected, $journal_entry->user_id);
+        $this->assertEquals($expected, $journal_entry->user);
+    }
+
+    /**
+     * @test
+     * @covers \Thtg88\LaravelBaseClasses\Helpers\JournalEntryHelper::createJournalEntry
+     */
+    public function content_is_null_if_not_provided(): void
+    {
+        $expected = null;
+
+        $journal_entry = $this->helper->createJournalEntry('ABCD');
+
+        $this->assertNotNull($journal_entry);
+        $this->assertInstanceOf(JournalEntry::class, $journal_entry);
+        $this->assertEquals($expected, $journal_entry->content);
+    }
+
+    /**
+     * @test
+     * @covers \Thtg88\LaravelBaseClasses\Helpers\JournalEntryHelper::createJournalEntry
+     */
+    public function no_model_does_not_set_target_id_and_target_type_test(): void
+    {
+        $journal_entry = $this->helper->createJournalEntry('ABCD');
+
+        $this->assertNotNull($journal_entry);
+        $this->assertInstanceOf(JournalEntry::class, $journal_entry);
+        $this->assertNull($journal_entry->target_id);
+        $this->assertNull($journal_entry->target_type);
+        $this->assertNull($journal_entry->target);
+    }
+
+    /**
+     * @test
+     * @covers \Thtg88\LaravelBaseClasses\Helpers\JournalEntryHelper::createJournalEntry
+     */
+    public function with_model_set_target_id_and_target_type_test(): void
+    {
+        $actual = $this->helper->createJournalEntry(
+            'ABCD',
+            $this->model
+        );
+
+        $this->assertNotNull($actual);
+        $this->assertInstanceOf(JournalEntry::class, $actual);
+        $this->assertNotNull($actual->target_id);
+        $this->assertNotNull($actual->target_type);
+        $this->assertNotNull($actual->target);
+        $this->assertTrue($actual->target->is($this->model));
+        $this->assertEquals($this->model->id, $actual->target_id);
+        $this->assertEquals($this->model->getTable(), $actual->target->getTable());
+    }
+
+    /**
+     * @test
+     * @covers \Thtg88\LaravelBaseClasses\Helpers\JournalEntryHelper::createJournalEntry
+     */
+    public function logged_in_user_gets_set_test(): void
+    {
+        $expected = User::factory()->create();
+        Auth::login($expected);
+
+        $journal_entry = $this->helper->createJournalEntry('ABCD');
+
+        $this->assertNotNull($journal_entry);
+        $this->assertInstanceOf(JournalEntry::class, $journal_entry);
+        $this->assertEquals($expected->id, $journal_entry->user_id);
+
+        Auth::logout();
+    }
+
+    /**
+     * @test
+     * @covers \Thtg88\LaravelBaseClasses\Helpers\JournalEntryHelper::createJournalEntry
+     */
+    public function content_gets_set(): void
+    {
+        $expected = ['foo' => 'bar'];
+
+        $journal_entry = $this->helper->createJournalEntry(
+            'ABCD',
+            null,
+            $expected,
+        );
+
+        $this->assertNotNull($journal_entry);
+        $this->assertInstanceOf(JournalEntry::class, $journal_entry);
+        $this->assertIsArray($journal_entry->content);
+        $this->assertEquals($expected, $journal_entry->content);
+    }
+
+    /**
+     * @test
+     * @covers \Thtg88\LaravelBaseClasses\Helpers\JournalEntryHelper::createJournalEntry
+     */
+    public function content_does_not_contain_secret_if_model_provided(): void
+    {
+        $expected = ['secret' => 'password'];
+
+        $journal_entry = $this->helper->createJournalEntry(
+            'ABCD',
+            $this->model,
+            $expected,
+        );
+
+        $this->assertNotNull($journal_entry);
+        $this->assertInstanceOf(JournalEntry::class, $journal_entry);
+        $this->assertIsArray($journal_entry->content);
+        $this->assertFalse(
+            array_key_exists('secret', $journal_entry->content)
+        );
+    }
+}


### PR DESCRIPTION
- Refactor get target table logic into dedicated method for journal entry helper
- Make sure `$action` is typed as string
- Refactor content handling logic
- Default model to `null` if N/A in `createJournalEntry`
- Don't extend base model in `JournalEntry` model
- Added `journal_entries` table migration
- Rename `target_table` of `JournalEntry` model to `target_type` to match Laravel convention
- Make sure journal entries' `content` is a JSONb column
- Added content `array` cast to journal entry and make sure to remove `json_encode` from helper
- Added `secret` to `TestModel` and migration
- Added journal entry helper tests
